### PR TITLE
Put a common "get_platform_tfvars.py" script in our Terraform wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 .releases
+.DS_Store
+*.tfvars

--- a/terraform_wrapper/Dockerfile
+++ b/terraform_wrapper/Dockerfile
@@ -1,11 +1,9 @@
 FROM hashicorp/terraform:0.11.0
 
 RUN apk update && apk add git jq python3
-RUN pip3 install awscli
+RUN pip3 install awscli boto3
 
-COPY plan.sh /app/plan.sh
-COPY run.sh /app/run.sh
-COPY notify.sh /app/notify.sh
+COPY . /app
 
 VOLUME ["/data"]
 WORKDIR /data

--- a/terraform_wrapper/get_platform_tfvars.py
+++ b/terraform_wrapper/get_platform_tfvars.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 """
 Downloads our terraform.tfvars file from the platform-infra S3 bucket,

--- a/terraform_wrapper/get_platform_tfvars.py
+++ b/terraform_wrapper/get_platform_tfvars.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""
+Downloads our terraform.tfvars file from the platform-infra S3 bucket,
+and fills in the ``release_ids`` variable.
+"""
+
+import os
+
+import boto3
+
+
+BUCKET = 'platform-infra'
+
+TFVARS_FILE = 'terraform.tfvars'
+
+
+def get_matching_s3_keys(bucket, prefix=''):
+    """
+    Generate the keys in an S3 bucket.
+
+    :param bucket: Name of the S3 bucket.
+    :param prefix: Only fetch keys that start with this prefix (optional).
+
+    """
+    s3 = boto3.client('s3')
+    kwargs = {'Bucket': bucket}
+
+    # If the prefix is a single string (not a tuple of strings), we can
+    # do the filtering directly in the S3 API.
+    if isinstance(prefix, str):
+        kwargs['Prefix'] = prefix
+
+    while True:
+
+        # The S3 API response is a large blob of metadata.
+        # 'Contents' contains information about the listed objects.
+        resp = s3.list_objects_v2(**kwargs)
+        for obj in resp['Contents']:
+            key = obj['Key']
+            if key.startswith(prefix):
+                yield key
+
+        # The S3 API is paginated, returning up to 1000 keys at a time.
+        # Pass the continuation token into the next response, until we
+        # reach the final page (when this field is missing).
+        try:
+            kwargs['ContinuationToken'] = resp['NextContinuationToken']
+        except KeyError:
+            break
+
+
+if __name__ == '__main__':
+    client = boto3.client('s3')
+    client.download_file(
+        Bucket=BUCKET,
+        Key='terraform.tfvars',
+        Filename=TFVARS_FILE
+    )
+
+    release_ids = {}
+    for key in get_matching_s3_keys(bucket=BUCKET, prefix='releases'):
+        release_id = client.get_object(
+            Bucket=BUCKET, Key=key
+        )['Body'].read()
+        release_ids[os.path.basename(key)] = release_id.decode('ascii').strip()
+
+    max_key_len = max(len(k) for k in release_ids)
+
+    with open(TFVARS_FILE, 'a') as outfile:
+        outfile.write('\n')
+        outfile.write('release_ids = {\n')
+        for key, release_id in release_ids.items():
+            outfile.write(f'  {key.ljust(max_key_len)} = "{release_id}"\n')
+        outfile.write('}\n')

--- a/terraform_wrapper/plan.sh
+++ b/terraform_wrapper/plan.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o verbose
 
 # Run the generate_tfvars hook script to prepare tfvars
-if [ -f generate_tfvars.sh ];
+if [ -f generate_tfvars.sh ]
 then
     ./generate_tfvars.sh
 fi

--- a/terraform_wrapper/plan.sh
+++ b/terraform_wrapper/plan.sh
@@ -4,6 +4,11 @@ set -o errexit
 set -o nounset
 set -o verbose
 
+if [[ "${GET_PLATFORM_TFVARS:-false}" == "true" ]]
+then
+  /app/get_platform_tfvars.py
+fi
+
 # Run the generate_tfvars hook script to prepare tfvars
 if [ -f generate_tfvars.sh ]
 then


### PR DESCRIPTION
Each of our Terraform stacks in the main repo has a generate_tfvars.sh script, which are similar but all slightly different. Since they all do the same thing, let’s pull that code into our standard container, hidden behind an environment variable.