### PR TITLE
Add Python base image

### DIFF
--- a/python3/Dockerfile
+++ b/python3/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine
+
+LABEL maintainer = "Wellcome Digital Platform team <wellcomedigitalplatform@wellcome.ac.uk>"
+LABEL description = "Python base image"
+
+RUN apk update && apk add build-base libffi-dev openssl-dev libzip-tools
+RUN apk update && apk add python3 python3-dev
+
+RUN python3 -m ensurepip && pip3 install --upgrade pip

--- a/python3/README.md
+++ b/python3/README.md
@@ -1,0 +1,4 @@
+# wellcome/python3
+
+Python3 base image for Wellcome projects built from Alpine linux.
+


### PR DESCRIPTION
In order that we can separate the base python build from other layers. 