### PR TITLE
Base build_tooling on Wellcome python base

### DIFF
--- a/build_tooling/Dockerfile
+++ b/build_tooling/Dockerfile
@@ -1,12 +1,9 @@
-FROM alpine
+FROM wellcome/python3
 
 LABEL maintainer = "Wellcome Digital Platform team <wellcomedigitalplatform@wellcome.ac.uk>"
 LABEL description = "Python build tooling base image"
 
-RUN apk update && apk add build-base libffi-dev openssl-dev libzip-tools
-RUN apk update && apk add git python3 python3-dev docker bash
-
-RUN python3 -m ensurepip && pip3 install --upgrade pip
+RUN apk update && apk add git docker bash
 
 COPY requirements.txt /requirements.txt
 RUN pip3 install -r /requirements.txt


### PR DESCRIPTION
In order that the python version is abstracted out.