### PR TITLE
Fix decoding bug in the publish_service scripts

### DIFF
--- a/publish_service/publish_service_to_aws.py
+++ b/publish_service/publish_service_to_aws.py
@@ -31,7 +31,7 @@ import docopt
 
 
 def cmd(*args):
-    return subprocess.check_output(list(args)).decode('ascii').strip()
+    return subprocess.check_output(list(args)).decode('utf8').strip()
 
 
 def git(*args):
@@ -61,9 +61,7 @@ def ecr_login():
     # the command that failed.  This may include AWS credentials, so we
     # want to suppress the output in an error!
     try:
-        command = subprocess.check_output([
-            'aws', 'ecr', 'get-login', '--no-include-email'
-        ]).decode('ascii')
+        command = cmd('aws', 'ecr', 'get-login', '--no-include-email')
         subprocess.check_call(shlex.split(command))
     except subprocess.CalledProcessError as err:
         sys.exit(err.returncode)


### PR DESCRIPTION
This is what’s breaking the master build on platform.

Compare the following commands when run from the root of the platform repo:

```console
$ python -c 'import subprocess; print(repr(subprocess.check_output(["git", "log", "-1", "--oneline", "--pretty=%B"]).decode("ascii")))'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 139: ordinal not in range(128)

$ python -c 'import subprocess; print(repr(subprocess.check_output(["git", "log", "-1", "--oneline", "--pretty=%B"]).decode("utf8")))'
'Merge pull request #1979 from wellcometrust/display-abstract-concept\n\nUse DisplayAbstractConcept in DisplayGenre and DisplaySubject models.…\n'
```