### PR TITLE
Don't manage release IDs as objects in S3; use SSM

### DIFF
--- a/publish_service/Dockerfile
+++ b/publish_service/Dockerfile
@@ -6,7 +6,7 @@ LABEL description "A Docker image for deploying our Docker images to AWS"
 RUN apk update && \
     apk add docker git python3
 
-RUN pip3 install awscli docopt boto3
+RUN pip3 install awscli click boto3
 
 COPY publish_service_to_aws.py /builds/publish_service_to_aws.py
 

--- a/terraform_wrapper/Dockerfile
+++ b/terraform_wrapper/Dockerfile
@@ -1,7 +1,7 @@
-FROM hashicorp/terraform:0.11.10
+FROM hashicorp/terraform:0.11.11
 
 RUN apk update && apk add git jq python3
-RUN pip3 install awscli boto3 pyhcl
+RUN pip3 install awscli boto3
 
 COPY app /app
 

--- a/terraform_wrapper/app/get_tfvars.py
+++ b/terraform_wrapper/app/get_tfvars.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
 """
-Downloads our .tfvars file from the specified S3 bucket,
-and fills in the ``release_ids`` variable.
+Downloads our .tfvars file from the specified S3 bucket.
 """
-
-import os
 
 import boto3
 
@@ -15,44 +12,6 @@ OBJECT_KEY = os.environ['OBJECT_KEY']
 
 TFVARS_FILE = 'terraform.tfvars'
 
-def get_matching_s3_keys(bucket, prefix=''):
-    """
-    Generate the keys in an S3 bucket.
-
-    :param bucket: Name of the S3 bucket.
-    :param prefix: Only fetch keys that start with this prefix (optional).
-
-    """
-    s3 = boto3.client('s3')
-    kwargs = {'Bucket': bucket}
-
-    # If the prefix is a single string (not a tuple of strings), we can
-    # do the filtering directly in the S3 API.
-    if isinstance(prefix, str):
-        kwargs['Prefix'] = prefix
-
-    while True:
-
-        # The S3 API response is a large blob of metadata.
-        # 'Contents' contains information about the listed objects.
-        resp = s3.list_objects_v2(**kwargs)
-
-        if not 'Contents' in resp:
-            break
-
-        for obj in resp['Contents']:
-            key = obj['Key']
-            if key.startswith(prefix) and not key.endswith("/"):
-                yield key
-
-        # The S3 API is paginated, returning up to 1000 keys at a time.
-        # Pass the continuation token into the next response, until we
-        # reach the final page (when this field is missing).
-        try:
-            kwargs['ContinuationToken'] = resp['NextContinuationToken']
-        except KeyError:
-            break
-
 
 if __name__ == '__main__':
     client = boto3.client('s3')
@@ -61,21 +20,3 @@ if __name__ == '__main__':
         Key=OBJECT_KEY,
         Filename=TFVARS_FILE
     )
-
-    release_ids = {}
-    for key in get_matching_s3_keys(bucket=BUCKET_NAME, prefix='releases'):
-        release_id = client.get_object(
-            Bucket=BUCKET_NAME,
-            Key=key
-        )['Body'].read()
-        release_ids[os.path.basename(key)] = release_id.decode('ascii').strip()
-
-    if release_ids:
-        max_key_len = max(len(k) for k in release_ids)
-
-        with open(TFVARS_FILE, 'a') as outfile:
-            outfile.write('\n')
-            outfile.write('release_ids = {\n')
-            for key, release_id in release_ids.items():
-                outfile.write(f'  {key.ljust(max_key_len)} = "{release_id}"\n')
-            outfile.write('}\n')


### PR DESCRIPTION
This patch:

* Simplifies the "publish service" container to remove the SNS publishing (which we don't really pay attention to, and could be supplied elsewhere), and use SSM to store image URLs rather than release IDs in S3.

* Simplifies the Terraform wrapper so that it doesn't download the release IDs.