### PR TITLE
terraformwrapper get_tfvars.py: import os to use os.environ

### DIFF
--- a/terraform_wrapper/app/get_tfvars.py
+++ b/terraform_wrapper/app/get_tfvars.py
@@ -3,7 +3,7 @@
 """
 Downloads our .tfvars file from the specified S3 bucket.
 """
-
+import os
 import boto3
 
 


### PR DESCRIPTION
avoid "NameError: name 'os' is not defined"