### PR TITLE
expect wellcome_project file for releases to be a JSON array

### DIFF
--- a/sbt_wrapper/Dockerfile
+++ b/sbt_wrapper/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Wellcome <wellcomedigitalplatform@wellcome.ac.uk>"
 LABEL description "A Docker image used for building sbt projects in the Wellcome Digital Platform"
 
 RUN apk add --update bash curl docker py-pip
-RUN pip install docker-compose
+RUN pip install docker-compose~=1.23.0
 
 ENV SBT_VERSION 0.13.17
 ENV SBT_HOME /usr/local/sbt


### PR DESCRIPTION
In the catalogue app, we have the pipeline and the api in the same project.

We could have created two separate files in each folder, but then would need some sort of reference to that.

Or we could just have 1 file that know about deploying the projects in a file.

An example of this is here:
https://github.com/wellcometrust/catalogue/pull/42