### PR TITLE
remove filter from logstash config

### DIFF
--- a/logstash_transit/Dockerfile
+++ b/logstash_transit/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/logstash/logstash:7.2.0
+FROM docker.elastic.co/logstash/logstash:7.3.0
 
 LABEL maintainer "Robert Kenny <R.Kenny@wellcome.ac.uk>"
 LABEL description "A Docker image for deploying logstash"

--- a/logstash_transit/pipeline/default.conf.template
+++ b/logstash_transit/pipeline/default.conf.template
@@ -1,30 +1,20 @@
 input {
     udp {
-        type => "json"
+        id => "${NAMESPACE}"
+        type => "syslog"
         port => 514
-        codec => json
-    }
-
-    tcp {
-        type => "json"
-        port => 5142
-        codec => json
+        codec => "json"
     }
 
     heartbeat {
+        type => "heartbeat"
         add_field => { 
             "namespace" => "${NAMESPACE}" 
         }
     }
 }
 
-filter {
-    if [type] == "json" {
-        json {
-            source => "message"
-        }
-    }
-}
+filter {}
 
 output {
     elasticsearch {


### PR DESCRIPTION
It's not needed. 

Also types the things so you can search by `syslog` or `heartbeat`, making it more similar to the docs.